### PR TITLE
Replace dagshub with huggingface

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,10 +49,10 @@ EXPOSE 8808
 # ENTRYPOINT [ "gunicorn", "-w", "8", "-k", "uvicorn.workers.UvicornWorker", "--bind", "0.0.0.0:8808", "src.trapi_oprenpredict.main:app"]
 
 # Build entrypoint script to pull latest dvc changes before startup
+
 RUN echo "#!/bin/bash" > /entrypoint.sh && \
     echo "huggingface-cli download um-ids/translator-openpredict --local-dir ./data --repo-type dataset" >> /entrypoint.sh && \
-    echo "/start.sh" >> /entrypoint.sh && \
+    echo "uvicorn trapi.main:app --host 0.0.0.0 --port 8808 --reload" >> /entrypoint.sh && \
     chmod +x /entrypoint.sh
-
 
 CMD [ "/entrypoint.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,11 +37,12 @@ ENV MODULE_NAME=trapi.main \
 
 # RUN pip install -e /app/predict-drug-target /app/trapi-predict-kit
 RUN pip install -e .
+RUN pip install "huggingface_hub[cli]"
+RUN pip install "trapi-predict-kit>=0.2.2"
 
 # RUN pip install -e . /app/predict-drug-target /app/trapi-predict-kit
 # RUN pip install -e /app/trapi-predict-kit
 
-RUN dvc pull -f
 
 EXPOSE 8808
 
@@ -49,7 +50,7 @@ EXPOSE 8808
 
 # Build entrypoint script to pull latest dvc changes before startup
 RUN echo "#!/bin/bash" > /entrypoint.sh && \
-    echo "dvc pull" >> /entrypoint.sh && \
+    echo "huggingface-cli download um-ids/translator-openpredict --local-dir ./data --repo-type dataset" >> /entrypoint.sh && \
     echo "/start.sh" >> /entrypoint.sh && \
     chmod +x /entrypoint.sh
 

--- a/README.md
+++ b/README.md
@@ -28,20 +28,20 @@ Requirements: Python 3.8+ and `pip` installed
    ```
 
 
-   ```
-
-
 2. Start the API in development mode with docker on http://localhost:8808, the API will automatically reload when you make changes in the code:
 
 ```bash
 docker compose up api
 ```
 
-(Note regarding the data file: The docker container should download the data automatically from the huggingface repo into the ```data``` subfolder. If, for any reason, you need to download separately, you can do this from the commandline using [`huggingface_cli`](https://huggingface.co/docs/huggingface_hub/main/en/guides/cli):
+[Note regarding the data file: The docker container should download the data automatically from the huggingface repo into the ```data``` subfolder. If, for any reason, you need to download separately, you can do this from the commandline using [`huggingface_cli`](https://huggingface.co/docs/huggingface_hub/main/en/guides/cli):
 
    ```bash
    huggingface-cli download um-ids/translator-openpredict \
-    --local-dir ./data/)
+    --local-dir ./data/
+    ``` 
+
+]
 
 > Contributions are welcome! If you wish to help improve OpenPredict, see the [instructions to contribute :woman_technologist:](/CONTRIBUTING.md) for more details on the development workflow
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This repository contains the code for the **OpenPredict Translator API** availab
 * the code for the OpenPredict API endpoints in  `src/trapi/` defines:
   *  a TRAPI endpoint returning predictions for the loaded models
 
-The data used by the models in this repository is versionned using `dvc` in the `data/` folder, and stored **on DagsHub at https://dagshub.com/vemonet/translator-openpredict**
+The data used by the models in this repository is downloaded into the `data/` folder, and stored **on HuggingFace at https://huggingface.co/datasets/um-ids/translator-openpredict**
 
 ### Deploy the OpenPredict API locally
 
@@ -27,11 +27,11 @@ Requirements: Python 3.8+ and `pip` installed
    cd translator-openpredict
    ```
 
-2. Pull the data required to run the models in the `data` folder with [`dvc`](https://dvc.org/):
+2. Pull the data required to run the models in the `data` folder with [`huggingface_cli`](https://huggingface.co/docs/huggingface_hub/main/en/guides/cli):
 
    ```bash
-   pip install dvc
-   dvc pull
+   huggingface-cli download um-ids/translator-openpredict \
+    --local-dir ./data/
    ```
 
 

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ docker compose up api
    ```bash
    huggingface-cli download um-ids/translator-openpredict \
     --local-dir ./data/
-    ``` 
-
+   ```
+The data can also be downloaded manually from the repo
 ]
 
 > Contributions are welcome! If you wish to help improve OpenPredict, see the [instructions to contribute :woman_technologist:](/CONTRIBUTING.md) for more details on the development workflow

--- a/README.md
+++ b/README.md
@@ -27,19 +27,21 @@ Requirements: Python 3.8+ and `pip` installed
    cd translator-openpredict
    ```
 
-2. Pull the data required to run the models in the `data` folder with [`huggingface_cli`](https://huggingface.co/docs/huggingface_hub/main/en/guides/cli):
 
-   ```bash
-   huggingface-cli download um-ids/translator-openpredict \
-    --local-dir ./data/
    ```
 
 
-Start the API in development mode with docker on http://localhost:8808, the API will automatically reload when you make changes in the code:
+2. Start the API in development mode with docker on http://localhost:8808, the API will automatically reload when you make changes in the code:
 
 ```bash
 docker compose up api
 ```
+
+(Note regarding the data file: The docker container should download the data automatically from the huggingface repo into the ```data``` subfolder. If, for any reason, you need to download separately, you can do this from the commandline using [`huggingface_cli`](https://huggingface.co/docs/huggingface_hub/main/en/guides/cli):
+
+   ```bash
+   huggingface-cli download um-ids/translator-openpredict \
+    --local-dir ./data/)
 
 > Contributions are welcome! If you wish to help improve OpenPredict, see the [instructions to contribute :woman_technologist:](/CONTRIBUTING.md) for more details on the development workflow
 

--- a/README.md
+++ b/README.md
@@ -34,13 +34,14 @@ Requirements: Python 3.8+ and `pip` installed
 docker compose up api
 ```
 
-[Note regarding the data file: The docker container should download the data automatically from the huggingface repo into the ```data``` subfolder. If, for any reason, you need to download separately, you can do this from the commandline using [`huggingface_cli`](https://huggingface.co/docs/huggingface_hub/main/en/guides/cli):
+[Note regarding the data files: The docker container should download the data automatically from the huggingface repo into the ```data``` subfolder. If, for any reason, you need to download separately, you can do this from the commandline using [`huggingface_cli`](https://huggingface.co/docs/huggingface_hub/main/en/guides/cli):
 
    ```bash
    huggingface-cli download um-ids/translator-openpredict \
-    --local-dir ./data/
+    --local-dir ./data/ --repo-type dataset
    ```
-The data can also be downloaded manually from the repo
+The data can also be downloaded manually from the repo if needed.
+
 ]
 
 > Contributions are welcome! If you wish to help improve OpenPredict, see the [instructions to contribute :woman_technologist:](/CONTRIBUTING.md) for more details on the development workflow

--- a/data.dvc
+++ b/data.dvc
@@ -1,5 +1,0 @@
-outs:
-- md5: 0359807a4366c756ad0f8e0deb8a87a0.dir
-  size: 139191128
-  nfiles: 70
-  path: data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,4 +13,4 @@ services:
       PYTHONUNBUFFERED: '1'
       LOG_LEVEL: 'INFO'
       NO_JAEGER: "true"
-    entrypoint: uvicorn trapi.main:app --host 0.0.0.0 --port 8808 --reload
+    

--- a/requirements.txt
+++ b/requirements.txt
@@ -258,6 +258,8 @@ hbreader==0.9.1
     #   jsonasobj2
     #   linkml
     #   linkml-runtime
+huggingface_hub>=0.28
+    #added Feb 2025 for the change from dvc to huggingface
 httpcore==0.18.0
     # via httpx
 httpx==0.25.0


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/MaastrichtU-IDS/translator-openpredict/blob/master/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] The existing suite of tests passes (`pytest`). 
- [ x] Docs have been reviewed and updated if needed (for bug fixes / features)
- [ x] Tests for the changes have been added (for bug fixes / features)


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:
- [x ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ x] Documentation content changes
- [ x] Other (please describe): moving the data from dagshub to huggingface - updated the docs accordingly


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
fixing docker file issues that were creating errors, changed the data source to the huggingface dataset repo

## Does this introduce a breaking change?

- [ ] Yes
- [ x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

The test suit is not passing but that was also the case before the PR. The cause of the tests not passing is a conflict in packages. WIll require significant restructuring of the project and separation of the training part from the API part
